### PR TITLE
Remove days display from time rendering function

### DIFF
--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -12,13 +12,11 @@ export const formatTimeDisplay = (seconds: number): string => {
 export const renderTime = (seconds: number) => {
   if (seconds === 0) return '0s'
 
-  const days = Math.floor(seconds / (24 * 60 * 60))
-  const hours = Math.floor((seconds % (24 * 60 * 60)) / (60 * 60))
+  const hours = Math.floor(seconds / (60 * 60))
   const minutes = Math.floor((seconds % (60 * 60)) / 60)
   const remainingSeconds = seconds % 60
 
   const parts = []
-  if (days > 0) parts.push(`${days}d`)
   if (hours > 0) parts.push(`${hours}h`)
   if (minutes > 0) parts.push(`${minutes}m`)
   if (remainingSeconds > 0 && parts.length === 0)


### PR DESCRIPTION
## Summary
Simplified the `renderTime` function to remove support for displaying days in time duration strings. The function now displays time in hours, minutes, and seconds only.

## Changes
- Removed `days` calculation and display logic from `renderTime`
- Updated `hours` calculation to use total seconds divided by seconds per hour (instead of modulo calculation)
- Removed the conditional check that added days to the output parts array

## Implementation Details
The hours calculation was changed from a modulo-based approach (calculating hours within a 24-hour period) to a simple division approach (total hours). This means durations longer than 24 hours will now display as multiple hours rather than being broken down into days and hours (e.g., "48h" instead of "2d").

https://claude.ai/code/session_01RqVsNXrsX9peptQABWszzu