### PR TITLE
Make keybindings cross-platform with dynamic modifier symbols

### DIFF
--- a/src/dev/FeatureFlags.tsx
+++ b/src/dev/FeatureFlags.tsx
@@ -1,7 +1,8 @@
 import { trpc } from '@/trpc/client'
+import { modName } from '@/lib/keys'
 
 const KNOWN_FLAGS = [
-  { key: 'document_undo', label: 'Document Undo', description: 'Enable document-level undo/redo (Cmd+Z / Cmd+Shift+Z)' },
+  { key: 'document_undo', label: 'Document Undo', description: `Enable document-level undo/redo (${modName}+Z / ${modName}+Shift+Z)` },
 ]
 
 export function FeatureFlags({ isActive }: { isActive: boolean }) {

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -1,5 +1,7 @@
 // keys.ts -- Key bindings
 
+import { isMac, modSymbol } from './platform'
+
 export interface Keybinding {
   /**
    * The key combination (e.g., 'meta+k', 'ctrl+shift+p')
@@ -11,39 +13,42 @@ export interface Keybinding {
   name: string
   /** Human-readable description of what the keybinding does */
   description: string
-  /** Display string for the key combination (e.g., '⌘ K') */
+  /** Display string for the key combination (e.g., '⌘ K' on Mac, 'Ctrl K' on others) */
   displayKey: string
   /** Type of keybinding - 'react' for react-hotkeys-hook, 'codemirror' for CodeMirror keymap */
   type: 'react' | 'codemirror'
 }
+
+/** Modifier key name for use in prose/tutorial text (e.g., 'Cmd' on Mac, 'Ctrl' on others) */
+export const modName = isMac ? 'Cmd' : 'Ctrl'
 
 export const keybindings = {
   documentSearch: {
     key: 'meta+o',
     name: 'document-search',
     description: 'Open a document',
-    displayKey: '⌘ O',
+    displayKey: `${modSymbol} O`,
     type: 'react' as const,
   },
   searchPanel: {
     key: 'meta+/',
     name: 'search-panel',
     description: 'Open search panel',
-    displayKey: '⌘ /',
+    displayKey: `${modSymbol} /`,
     type: 'react' as const,
   },
   commandPalette: {
     key: 'meta+k',
     name: 'command-palette',
     description: 'Open command palette',
-    displayKey: '⌘ K',
+    displayKey: `${modSymbol} K`,
     type: 'react' as const,
   },
   toggleCollapse: {
-    key: 'Cmd-.',
+    key: 'Mod-.',
     name: 'toggle-collapse',
     description: 'Toggle line collapse',
-    displayKey: '⌘ .',
+    displayKey: `${modSymbol} .`,
     type: 'codemirror' as const,
   },
   goToLine: {
@@ -53,7 +58,7 @@ export const keybindings = {
     displayKey: 'Ctrl G',
     type: 'react' as const,
   },
-} as const satisfies Record<string, Keybinding>
+} satisfies Record<string, Keybinding>
 
 /** Get all keybindings as an array */
 export const getAllKeybindings = (): Keybinding[] => {

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,8 @@
+// platform.ts -- Platform detection for cross-platform keybindings
+
+export const isMac =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+
+/** Modifier symbol for display: ⌘ on Mac, Ctrl on other platforms */
+export const modSymbol = isMac ? '⌘' : 'Ctrl'

--- a/src/lib/tutorial.ts
+++ b/src/lib/tutorial.ts
@@ -1,4 +1,5 @@
 import { lineMake } from '@/docs/schema'
+import { modName } from './keys'
 
 export const makeTutorial = () => {
   let i = 0
@@ -17,7 +18,7 @@ export const makeTutorial = () => {
       ++i,
       'Lines can be indented with `Tab` and de-dented with `Shift-Tab`'
     ),
-    lineMake(--i, 'You can collapse a group of indented lines with `Cmd-.`'),
+    lineMake(--i, `You can collapse a group of indented lines with \`${modName}-.\``),
     lineMake(
       ++i,
       'Try it out by selecting the above line and then using the key binding'
@@ -76,9 +77,9 @@ export const makeTutorial = () => {
       }
     ),
     lineMake((i = 0), '# Navigation'),
-    lineMake(++i, 'You can open or create documents with `Cmd-O`'),
-    lineMake(i, 'You can search across all documents with `Cmd-/`'),
-    lineMake(i, 'And trigger a command palette with `Cmd-K`'),
+    lineMake(++i, `You can open or create documents with \`${modName}-O\``),
+    lineMake(i, `You can search across all documents with \`${modName}-/\``),
+    lineMake(i, `And trigger a command palette with \`${modName}-K\``),
     lineMake(i, 'For more help, see the help section of the side panel'),
     lineMake(
       i,

--- a/src/panel/Help.tsx
+++ b/src/panel/Help.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionList,
   DescriptionTerm,
 } from '@/components/vendor/DescriptionList'
-import { getAllKeybindings } from '@/lib/keys'
+import { getAllKeybindings, keybindings } from '@/lib/keys'
 import { DocsWrapper } from '@/documentation/DocsWrapper'
 import { Button } from '@/components/vendor/Button'
 import { Version } from '@/documentation/Version'
@@ -43,7 +43,7 @@ const Keybindings = () => {
 
       <h3 className="text-base font-semibold mb-2 mt-6">Command Palette Shortcuts</h3>
       <p className="text-sm text-gray-400 mb-2">
-        Press <Badge className="inline">⌘K</Badge> to open the command palette, then press any of these keys:
+        Press <Badge className="inline">{keybindings.commandPalette.displayKey}</Badge> to open the command palette, then press any of these keys:
       </p>
       <DescriptionList>
         {commandShortcuts.map((command) => (


### PR DESCRIPTION
## Summary
This PR introduces cross-platform keybinding support by dynamically detecting the platform (Mac vs. others) and adjusting modifier key symbols and names accordingly. This ensures keybindings display correctly for each platform (⌘ on Mac, Ctrl elsewhere).

## Key Changes
- **New `platform.ts` module**: Added platform detection utilities (`isMac` and `modSymbol`) to determine the user's operating system and provide the appropriate modifier symbol
- **Updated `keys.ts`**: 
  - Imported platform detection utilities
  - Exported `modName` constant for use in prose/tutorial text ('Cmd' on Mac, 'Ctrl' on others)
  - Changed all hardcoded `⌘` symbols to use the dynamic `modSymbol` variable
  - Fixed `toggleCollapse` keybinding from `'Cmd-.'` to `'Mod-.'` for proper CodeMirror compatibility
  - Removed `as const` assertion from keybindings object to allow dynamic displayKey values
- **Updated `tutorial.ts`**: Replaced hardcoded `Cmd` references with dynamic `modName` variable in tutorial text
- **Updated `Help.tsx`**: Changed hardcoded `⌘K` badge to use `keybindings.commandPalette.displayKey` for consistency
- **Updated `FeatureFlags.tsx`**: Used dynamic `modName` in feature flag descriptions

## Implementation Details
- Platform detection uses `navigator.platform` to identify Mac systems (including iPhone/iPad)
- The solution maintains backward compatibility while providing a better user experience across platforms
- All keybinding display strings now dynamically reflect the user's platform

https://claude.ai/code/session_01Lu45RWD54KDkAif3bimczB