### PR TITLE
Add delete line command with Mod-Shift-K keybinding

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -2,11 +2,11 @@
 
 import type { Command } from './types'
 import { emitCodemirrorEvent } from '@/editor/line-editor/cm-events'
+import { deleteLine } from '@/editor/line-editor/line-operations'
 import { formatDate, getDocTitle } from '@/lib/utils'
 import { trpcClient } from '@/trpc/client'
 import { getDefaultStore } from 'jotai'
 import { panelVisibleAtom } from '@/panel/state'
-import { docAtom, requestFocusLineAtom } from '@/editor/state'
 
 /** Check if a string is a valid YYYY-MM-DD date */
 const isDateString = (str: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(str)
@@ -163,28 +163,7 @@ const editorCommands: Command[] = [
         description: 'Delete the entire current line',
         execute: ({ lineIdx }) => {
           if (lineIdx === null) return
-          const store = getDefaultStore()
-          const doc = store.get(docAtom)
-
-          // Don't delete the last remaining line, clear it instead
-          if (doc.children.length === 1) {
-            store.set(docAtom, (draft) => {
-              draft.children[lineIdx].mdContent = ''
-            })
-            return
-          }
-
-          const focusIdx = lineIdx > 0 ? lineIdx - 1 : 0
-          const focusPos = doc.children[focusIdx]?.mdContent.length ?? 0
-
-          store.set(requestFocusLineAtom, {
-            lineIdx: focusIdx,
-            pos: focusPos,
-          })
-
-          store.set(docAtom, (draft) => {
-            draft.children.splice(lineIdx, 1)
-          })
+          deleteLine(lineIdx)
         },
       },
     ],

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -6,6 +6,7 @@ import { formatDate, getDocTitle } from '@/lib/utils'
 import { trpcClient } from '@/trpc/client'
 import { getDefaultStore } from 'jotai'
 import { panelVisibleAtom } from '@/panel/state'
+import { docAtom, requestFocusLineAtom } from '@/editor/state'
 
 /** Check if a string is a valid YYYY-MM-DD date */
 const isDateString = (str: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(str)
@@ -144,6 +145,51 @@ const editorCommands: Command[] = [
           insert: date,
         },
       })
+    },
+  },
+  {
+    id: 'line-edit',
+    name: 'Line edit',
+    description: 'Line editing shortcuts',
+    shortcut: 'l',
+    displayShortcut: 'L',
+    keywords: ['line', 'edit', 'delete', 'remove'],
+    requiresEditor: true,
+    subcommands: [
+      {
+        key: 'd',
+        displayKey: 'D',
+        name: 'Delete line',
+        description: 'Delete the entire current line',
+        execute: ({ lineIdx }) => {
+          if (lineIdx === null) return
+          const store = getDefaultStore()
+          const doc = store.get(docAtom)
+
+          // Don't delete the last remaining line, clear it instead
+          if (doc.children.length === 1) {
+            store.set(docAtom, (draft) => {
+              draft.children[lineIdx].mdContent = ''
+            })
+            return
+          }
+
+          const focusIdx = lineIdx > 0 ? lineIdx - 1 : 0
+          const focusPos = doc.children[focusIdx]?.mdContent.length ?? 0
+
+          store.set(requestFocusLineAtom, {
+            lineIdx: focusIdx,
+            pos: focusPos,
+          })
+
+          store.set(docAtom, (draft) => {
+            draft.children.splice(lineIdx, 1)
+          })
+        },
+      },
+    ],
+    execute: () => {
+      // Parent command doesn't execute directly when subcommands exist
     },
   },
 ]

--- a/src/editor/line-editor/line-operations.ts
+++ b/src/editor/line-editor/line-operations.ts
@@ -6,7 +6,32 @@ import { documentUndoEnabledAtom } from '@/lib/feature-flags'
 import { lineMake, type ZDoc } from '@/docs/schema'
 import { keybindings } from '@/lib/keys'
 import type { useStore } from 'jotai'
+import { getDefaultStore } from 'jotai'
 import { Transaction } from '@codemirror/state'
+
+/** Delete an entire line by index, moving focus to the previous line.
+ *  If it's the last remaining line, clears its content instead. */
+export const deleteLine = (lineIdx: number, store?: ReturnType<typeof useStore>) => {
+  const s = store ?? getDefaultStore()
+  const doc = s.get(docAtom)
+
+  if (doc.children.length === 1) {
+    s.set(docAtom, (draft: ZDoc) => {
+      draft.children[lineIdx].mdContent = ''
+    })
+    return
+  }
+
+  const focusIdx = lineIdx > 0 ? lineIdx - 1 : 0
+  s.set(requestFocusLineAtom, {
+    lineIdx: focusIdx,
+    pos: doc.children[focusIdx]?.mdContent.length ?? 0,
+  })
+
+  s.set(docAtom, (draft: ZDoc) => {
+    draft.children.splice(lineIdx, 1)
+  })
+}
 
 export const toggleCollapse = (
   view: EditorView,
@@ -258,25 +283,7 @@ export const makeKeymap = (
     {
       key: 'Mod-Shift-k',
       run: () => {
-        const lineIdx = getLineIdx()
-
-        // Don't delete the last remaining line, clear it instead
-        if (doc.children.length === 1) {
-          setDoc((draft: ZDoc) => {
-            draft.children[lineIdx].mdContent = ''
-          })
-          return true
-        }
-
-        const focusIdx = lineIdx > 0 ? lineIdx - 1 : 0
-        setRequestFocusLine({
-          lineIdx: focusIdx,
-          pos: doc.children[focusIdx]?.mdContent.length ?? 0,
-        })
-
-        setDoc((draft: ZDoc) => {
-          draft.children.splice(lineIdx, 1)
-        })
+        deleteLine(getLineIdx(), store)
         return true
       },
     },

--- a/src/editor/line-editor/line-operations.ts
+++ b/src/editor/line-editor/line-operations.ts
@@ -255,6 +255,31 @@ export const makeKeymap = (
       key: 'Alt-Backspace',
       run: (view) => deleteLineIfEmpty(view),
     },
+    {
+      key: 'Mod-Shift-k',
+      run: () => {
+        const lineIdx = getLineIdx()
+
+        // Don't delete the last remaining line, clear it instead
+        if (doc.children.length === 1) {
+          setDoc((draft: ZDoc) => {
+            draft.children[lineIdx].mdContent = ''
+          })
+          return true
+        }
+
+        const focusIdx = lineIdx > 0 ? lineIdx - 1 : 0
+        setRequestFocusLine({
+          lineIdx: focusIdx,
+          pos: doc.children[focusIdx]?.mdContent.length ?? 0,
+        })
+
+        setDoc((draft: ZDoc) => {
+          draft.children.splice(lineIdx, 1)
+        })
+        return true
+      },
+    },
   ])
 
   // Undo/redo uses domEventHandlers instead of keymap bindings because

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -58,6 +58,13 @@ export const keybindings = {
     displayKey: 'Ctrl G',
     type: 'react' as const,
   },
+  deleteLine: {
+    key: 'Mod-Shift-k',
+    name: 'delete-line',
+    description: 'Delete the entire current line',
+    displayKey: `${modSymbol} Shift K`,
+    type: 'codemirror' as const,
+  },
 } satisfies Record<string, Keybinding>
 
 /** Get all keybindings as an array */


### PR DESCRIPTION
## Summary
This PR adds a delete line feature to the editor, allowing users to delete the entire current line using the `Mod-Shift-K` keyboard shortcut (Ctrl+Shift+K on Windows/Linux, Cmd+Shift+K on Mac).

## Key Changes
- **Command Registry**: Added a new `line-edit` parent command with a `delete-line` subcommand that removes the current line from the document
- **Line Operations**: Implemented the `Mod-Shift-K` keybinding in the CodeMirror keymap to trigger line deletion
- **Keybindings Registry**: Registered the new `deleteLine` keybinding with appropriate display text for different platforms

## Implementation Details
- When deleting a line, the editor focuses on the previous line (or the first line if deleting the first line)
- Special handling prevents deletion of the last remaining line; instead, it clears the line content
- The focus position is set to the end of the target line to maintain a natural editing experience
- The implementation uses Jotai atoms (`docAtom` and `requestFocusLineAtom`) for state management, consistent with the existing editor architecture

https://claude.ai/code/session_01SNb3UPe18xkqL2UzH7P9gh