### PR TITLE
fix Cmd-Shift-K opening command palette alongside delete line

### DIFF
--- a/src/commands/CommandPaletteProvider.tsx
+++ b/src/commands/CommandPaletteProvider.tsx
@@ -16,7 +16,7 @@ export const CommandPaletteProvider: React.FC<{
     const handleKeyDown = (e: KeyboardEvent) => {
       const isMod = e.metaKey || e.ctrlKey
 
-      if (isMod && e.key === 'k') {
+      if (isMod && e.key === 'k' && !e.shiftKey) {
         e.preventDefault()
         setPaletteOpen((open) => !open)
       }


### PR DESCRIPTION
The Cmd-K handler in CommandPaletteProvider matched any keydown with mod+k regardless of shift state, so Cmd-Shift-K (delete line) also toggled the command palette. Add !e.shiftKey guard to only match plain Cmd-K.

https://claude.ai/code/session_01SNb3UPe18xkqL2UzH7P9gh