### PR TITLE
Fix command palette keyboard shortcut for non-Mac platforms

### DIFF
--- a/src/commands/CommandPaletteProvider.tsx
+++ b/src/commands/CommandPaletteProvider.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { focusedLineAtom, commandPaletteOpenAtom } from '@/editor/state'
 import { CommandPalette } from './CommandPalette'
+import { isMac } from '@/lib/platform'
 
 export const CommandPaletteProvider: React.FC<{
   children: React.ReactNode
@@ -14,7 +15,7 @@ export const CommandPaletteProvider: React.FC<{
   // Listen for Cmd-K to toggle palette
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isMod = e.metaKey || e.ctrlKey
+      const isMod = isMac ? e.metaKey : e.ctrlKey
 
       if (isMod && e.key === 'k' && !e.shiftKey) {
         e.preventDefault()


### PR DESCRIPTION
## Summary
Updated the command palette keyboard shortcut detection to use platform-specific modifier keys. On Mac, the shortcut uses Cmd+K, while on other platforms it uses Ctrl+K.

## Changes
- Added import of `isMac` platform detection utility
- Modified keyboard event handler to check `e.metaKey` only on Mac and `e.ctrlKey` on other platforms, instead of accepting either modifier on all platforms

## Details
Previously, the command palette could be triggered with either Cmd or Ctrl on any platform. This change ensures the correct platform convention is followed:
- **Mac**: Cmd+K (metaKey)
- **Other platforms**: Ctrl+K (ctrlKey)

This provides a more native user experience by respecting platform-specific keyboard conventions.

https://claude.ai/code/session_014uszgRJkZKsRPBB3wpwofL