### PR TITLE
Fix TimerBadge initial state when time is undefined

### DIFF
--- a/src/editor/TimerBadge.tsx
+++ b/src/editor/TimerBadge.tsx
@@ -129,7 +129,7 @@ export const TimerBadge = ({
     globalTimer.isActive && globalTimer.lineTimeCreated === lineInfo.line.timeCreated
   const isAnyTimerActive = globalTimer.isActive
 
-  const [timeInput, setTimeInput] = React.useState(renderTime(time))
+  const [timeInput, setTimeInput] = React.useState(time ? renderTime(time) : '')
   const [countdownInput, setCountdownInput] = React.useState('30m')
   const [timerDialogRequest, setTimerDialogRequest] = useAtom(timerDialogRequestAtom)
 


### PR DESCRIPTION
## Summary
Fixed a bug in the TimerBadge component where the initial `timeInput` state could be set to an invalid value when `time` is undefined or null.

## Changes
- Updated the `timeInput` state initialization to conditionally render the time value
  - When `time` exists: uses `renderTime(time)` to format the time
  - When `time` is falsy: initializes to an empty string instead of calling `renderTime(undefined)`

## Details
This prevents potential runtime errors or unexpected behavior that could occur when `renderTime()` is called with an undefined/null value. The empty string provides a sensible default state for the input field when no time value is available.

https://claude.ai/code/session_01JKjoJLbC19TF4ymxdZMkyv