### PR TITLE
Make hook execution non-blocking to prevent UI lockups

### DIFF
--- a/src/trpc/router.ts
+++ b/src/trpc/router.ts
@@ -8,6 +8,7 @@ import { flagsRouter } from './routers/flags'
 
 import fs from 'fs'
 import child_process from 'child_process'
+import path from 'path'
 
 export const appRouter = router({
   doc: docRouter,
@@ -44,15 +45,38 @@ export const appRouter = router({
         if (hook === 'timer-start' || hook === 'timer-stop') {
           const { line, lineIdx, doc } = argument
 
-          if (fs.existsSync(`hooks/${hook}`)) {
-            child_process.execSync(`hooks/${hook}`, {
-              input: JSON.stringify({
+          const hookPath = path.resolve('hooks', hook)
+
+          if (fs.existsSync(hookPath)) {
+            const child = child_process.spawn(hookPath, [], {
+              stdio: ['pipe', 'ignore', 'pipe'],
+            })
+
+            const timeout = setTimeout(() => {
+              child.kill('SIGKILL')
+            }, 5_000)
+
+            child.on('close', () => {
+              clearTimeout(timeout)
+            })
+
+            child.stderr.on('data', (chunk) => {
+              console.error('[hook] execHook stderr', hook, chunk.toString())
+            })
+
+            child.on('error', (error) => {
+              console.error('[hook] execHook failed', hook, error)
+            })
+
+            child.stdin.write(
+              JSON.stringify({
                 type: 'timer-event',
                 line,
                 lineIdx,
                 doc,
-              }),
-            })
+              })
+            )
+            child.stdin.end()
           }
         }
       } else {


### PR DESCRIPTION
### Motivation
- Hook scripts were executed with `child_process.execSync`, which blocks the Node.js event loop and can cause the app/requests to appear frozen if a hook stalls. 
- The change aims to eliminate that blocking behavior and make hook handling robust to misbehaving scripts.

### Description
- Replaced synchronous `execSync` hook execution with an asynchronous `child_process.spawn` invocation that streams JSON to the hook's `stdin`.
- Resolve the hook executable path with `path.resolve('hooks', hook)` before running to avoid ambiguity about the hook location.
- Add a 5 second timeout that force-kills the child process with `SIGKILL` to guard against long-running or stuck hooks.
- Log `stderr` data and process `error` events to improve observability when hooks fail.

### Testing
- Ran `pnpm types` and the TypeScript check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11169b4c7c832b90fc5c6a85e7bbab)